### PR TITLE
I fixed a bug in the ! cut

### DIFF
--- a/fibo.pl
+++ b/fibo.pl
@@ -1,0 +1,15 @@
+fib(N, F) :- N < 2, !,  F is N + 1.
+fib(2, 3) :- !. 
+fib(N, F) :-  N3 is N - 3, N2 is N - 2, fib(N3, F3), 
+             fib(N2, F2), F is F3 + F2 + F2.
+
+fibo(0, F1, F2, F2) :- !.
+fibo(1, F1, F2, F1) :- !.
+fibo(N, F1, F2, F) :- N1 is N - 1, Fx is F1+F2, fibo(N1, Fx, F1, F).
+
+fibx(N, F) :- fibo(N, 1, 1, F).
+
+loop(0, Acc, Acc) :- !.
+loop(N, Acc, F) :- plus(A1, Acc, 0.1), minus(N1, N, 1), loop(N1, A1, F).
+
+

--- a/gram.pl
+++ b/gram.pl
@@ -1,0 +1,16 @@
+article(c, [the|S], S).
+article(c, [a|S], S).
+
+noun(c, [cat|S], S).
+noun(c, [mouse|S], S).
+
+np(S, S0) :- article(G, S, S1), noun(G, S1, S0).
+
+tverb([caught|S], S).
+iverb([fled|S], S).
+
+vp(S, S0) :- tverb(S, S1), np(S1, S0).
+vp(S, S0) :- iverb(S, S0).
+
+phrase(S, S0) :- np(S, S1), vp(S1, S0).
+

--- a/prelude.pl
+++ b/prelude.pl
@@ -91,6 +91,8 @@ subset([],_).
 subset([A|R],B):-member(A,B),subset(R,B).
 :-builtin_lock(subset,2).
 
-tarai(X,Y,Z,Result):-X=<Y,Result is Y,!.
-tarai(X,Y,Z,Result):-X1 is X-1,Y1 is Y-1,Z1 is Z-1,tarai(X1,Y,Z,R1),tarai(Y1,Z,X,R2),tarai(Z1,X,Y,R3),tarai(R1,R2,R3,Result).
+tarai(X,Y,Z,Result):- X=<Y, !, Result is Y.
+tarai(X,Y,Z,Result):- X1 is X-1, Y1 is Y-1, Z1 is Z-1, 
+   tarai(X1,Y,Z,R1), tarai(Y1,Z,X,R2), tarai(Z1,X,Y,R3),
+   tarai(R1,R2,R3,Result).
 

--- a/wamcompiler.lisp
+++ b/wamcompiler.lisp
@@ -2524,7 +2524,7 @@ heap: -2,-4,-6,...
 				(setf (stack (addr+ *E* 2 y)) *B0*))
 			      (setq *P* (cdr *P*)))
 		   (cut (let ( (y (cadr inst)) )
-			  (when (and *B* *E* (>= *B* 0) (>= *E* 0) 
+			  (when (and *B* *E* 
 				     (addr< (stack (addr+ *E* 2 y)) *B*))
 			    (setf *B* (stack (addr+ *E* 2 y)))
 			    (tidy-trail))


### PR DESCRIPTION
I fixed two bugs in the ! cut. Besides this, I added a few predicates, such as cputime(X), which can be useful for benchmarks. 

A third bug remains to be fixed. I still canot use a cut as the last element of a clause body. When the cut appears in the last position of the body, *E* or *B* become large negative numbers. I added predicates that check whether *E* or *B* are negative to prevent the execution of the cut in this case. However, this is a temporary solution:

```Lisp
;;; Temporary solution: turn the cut off, when *B* or *E* are negative
   (cut (let ( (y (cadr inst)) )
			  (when (and *B* *E* (>= *B* 0) (>= *E* 0) 
				     (addr< (stack (addr+ *E* 2 y)) *B*))
			    (setf *B* (stack (addr+ *E* 2 y)))
			    (tidy-trail))
			  (setq *P* (cdr *P*))))
```
